### PR TITLE
Fix typo in permission node

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 - /signin：签到
 - /signin_week：领取连续签到奖励
 # 三、权限节点
-- pcc.comman.gonggao：插件主指令
+- pcc.command.gonggao：插件主指令
 - pcc.command.gonggao：发布公告
 - pcc.command.shout：喊话
 - pcc.command.stop：倒计时关服


### PR DESCRIPTION
## Summary
- correct `pcc.comman.gonggao` to `pcc.command.gonggao`

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d83d331fc832692f7ba48310df125