### PR TITLE
Add JUnit test for MarkdownRenderer

### DIFF
--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,1 @@
+--settings .mvn/settings.xml

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,0 +1,11 @@
+<settings>
+  <proxies>
+    <proxy>
+      <id>proxy</id>
+      <active>true</active>
+      <protocol>http</protocol>
+      <host>proxy</host>
+      <port>8080</port>
+    </proxy>
+  </proxies>
+</settings>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,13 @@
         </resources>
     </build>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
+        </pluginRepository>
+    </pluginRepositories>
+
     <repositories>
         <repository>
             <id>spigotmc-repo</id>
@@ -60,6 +67,10 @@
         <repository>
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/groups/public/</url>
+        </repository>
+        <repository>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2</url>
         </repository>
     </repositories>
 
@@ -74,6 +85,12 @@
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>4.12.0</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/test/java/limbo/pcc/pcc_limbo_system/task/MarkdownRendererTest.java
+++ b/src/test/java/limbo/pcc/pcc_limbo_system/task/MarkdownRendererTest.java
@@ -1,0 +1,29 @@
+package limbo.pcc.pcc_limbo_system.task;
+
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.TextComponent;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class MarkdownRendererTest {
+    @Test
+    public void testBoldRendering() {
+        BaseComponent[] result = MarkdownRenderer.renderMarkdown("**text**");
+        assertEquals("Expected one root component", 1, result.length);
+        assertTrue("Root component should be TextComponent", result[0] instanceof TextComponent);
+
+        TextComponent container = (TextComponent) result[0];
+        assertNotNull("Container extras should not be null", container.getExtra());
+        assertFalse("Container should have at least one child", container.getExtra().isEmpty());
+
+        // The first child is the processed line, which itself contains the formatted text
+        assertTrue(container.getExtra().get(0) instanceof TextComponent);
+        TextComponent line = (TextComponent) container.getExtra().get(0);
+        assertNotNull(line.getExtra());
+        assertTrue(line.getExtra().size() > 1);
+
+        BaseComponent bold = line.getExtra().get(1);
+        assertTrue("Child component should be bold", bold.isBold());
+        assertEquals("text", bold.toPlainText());
+    }
+}


### PR DESCRIPTION
## Summary
- fix MarkdownRendererTest structure checks
- add plugin and repository entries for Maven Central mirror
- configure Maven proxy so `mvn test` can resolve dependencies

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_684d83e4fba4832684c15958c2a91fd7