### PR TITLE
Use JDK 21 in PR build workflow

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,20 @@
+name: Build on PR
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 21
+      uses: actions/setup-java@v3
+      with:
+        java-version: '21'
+        distribution: 'temurin'
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+


### PR DESCRIPTION
## Summary
- update the PR build workflow to use JDK 21

## Testing
- `mvn -B package --file pom.xml` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684d8b9f51ac832687e230b9d9e1ba32